### PR TITLE
feat(website): integrate language provider and static params

### DIFF
--- a/apps/website/app/[lang]/layout.tsx
+++ b/apps/website/app/[lang]/layout.tsx
@@ -1,5 +1,21 @@
 import type { ReactNode } from "react";
+import I18nProvider from "@/components/I18nProvider";
+import { setLanguage as syncLanguage } from "@hikai/i18n";
 
-export default function LangLayout({ children }: { children: ReactNode }) {
-	return <>{children}</>;
+const SUPPORTED_LANGS = ["en", "es"] as const;
+
+export function generateStaticParams() {
+        return SUPPORTED_LANGS.map((lang) => ({ lang }));
 }
+
+export default function LangLayout({
+        children,
+        params,
+}: {
+        children: ReactNode;
+        params: { lang: string };
+}) {
+        syncLanguage(params.lang);
+        return <I18nProvider lang={params.lang}>{children}</I18nProvider>;
+}
+

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -15,19 +15,20 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({
-	children,
+        children,
+        params,
 }: {
-	children: React.ReactNode;
+        children: React.ReactNode;
+        params: { lang?: string };
 }) {
-	return (
-		<html lang="en">
-			{" "}
-			{/* fallback; ver i18n en [lang]/layout.tsx */}
-			<body
-				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-			>
-				{children}
-			</body>
-		</html>
-	);
+        return (
+                <html lang={params.lang ?? "en"}>
+                        {/* fallback; ver i18n en [lang]/layout.tsx */}
+                        <body
+                                className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+                        >
+                                {children}
+                        </body>
+                </html>
+        );
 }

--- a/apps/website/components/I18nProvider.tsx
+++ b/apps/website/components/I18nProvider.tsx
@@ -1,9 +1,19 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import { I18nextProvider } from "@hikai/i18n/client";
-import { i18n } from "@hikai/i18n"; // tu instancia inicializada en create-i18n.ts
+import { i18n, setLanguage as syncLanguage } from "@hikai/i18n"; // tu instancia inicializada en create-i18n.ts
 
-export default function I18nProvider({ children }: { children: ReactNode }) {
-	return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+export default function I18nProvider({
+        lang,
+        children,
+}: {
+        lang: string;
+        children: ReactNode;
+}) {
+        useEffect(() => {
+                syncLanguage(lang);
+        }, [lang]);
+
+        return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }


### PR DESCRIPTION
## Summary
- wire language-aware layout that syncs locale and wraps pages in I18nProvider
- surface supported languages via generateStaticParams
- set root `<html>` lang attribute from route params and keep client language in sync

## Testing
- `pnpm lint --filter=website`
- `pnpm build --filter=website` *(fails: Module not found: Package path ./client is not exported from package @hikai/i18n)*

------
https://chatgpt.com/codex/tasks/task_e_68a16e501b3c833296e8eeaa39fac6d6