### PR TITLE
feat: add i18n locales and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ packages/
 pnpm install                 # Instala todas las dependencias del monorepo
 pnpm dev                     # Inicia todas las apps en modo desarrollo
 pnpm lint                    # Ejecuta el linter en todo el monorepo
+pnpm i18n:check              # Verifica llaves faltantes/extra en las traducciones
 pnpm turbo run build         # Compila todos los paquetes/apps
 pnpm turbo run build --filter=@hikai/i18n   # Compila sólo un paquete
 ```
@@ -49,6 +50,12 @@ pnpm test                    # Ejecuta los tests unitarios con Vitest
 ```
 
 > Los paquetes están configurados para compilar usando `tsc --build`, lo que permite builds incrementales.
+
+## 🌍 Añadir o actualizar traducciones
+
+1. Las traducciones viven en `packages/i18n/locales/` como archivos `*.json`.
+2. Duplica `en.json` para crear un nuevo idioma y mantiene la misma estructura de llaves.
+3. Ejecuta `pnpm i18n:check` para verificar que no falten o sobren llaves antes de commitear.
 
 ## 🧪 Tests con Vitest
 

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
 	"scripts": {
 		"dev": "pnpm turbo run dev",
 		"build": "pnpm turbo run build",
-		"lint": "pnpm turbo run lint",
-		"lint:fix": "pnpm turbo run lint -- --fix",
-		"format": "prettier --write .",
-		"format:check": "prettier --check ."
-	},
-	"devDependencies": {
+                "lint": "pnpm turbo run lint",
+                "lint:fix": "pnpm turbo run lint -- --fix",
+                "format": "prettier --write .",
+                "format:check": "prettier --check .",
+                "i18n:check": "node packages/i18n/scripts/check-locales.mjs"
+        },
+        "devDependencies": {
 		"@eslint/css": "^0.10.0",
 		"@eslint/js": "^9.31.0",
 		"@eslint/json": "^0.13.0",

--- a/packages/i18n/locales/en.json
+++ b/packages/i18n/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "greeting": "Hello",
+  "farewell": "Goodbye"
+}

--- a/packages/i18n/locales/es.json
+++ b/packages/i18n/locales/es.json
@@ -1,0 +1,4 @@
+{
+  "greeting": "Hola",
+  "farewell": "Adiós"
+}

--- a/packages/i18n/scripts/check-locales.mjs
+++ b/packages/i18n/scripts/check-locales.mjs
@@ -1,0 +1,53 @@
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const localesDir = path.resolve(__dirname, '../locales');
+const files = readdirSync(localesDir).filter(f => f.endsWith('.json')).sort();
+
+if (files.length === 0) {
+  console.error('No locale files found.');
+  process.exit(1);
+}
+
+function flatten(obj, prefix = '', res = {}) {
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      flatten(value, fullKey, res);
+    } else {
+      res[fullKey] = true;
+    }
+  }
+  return res;
+}
+
+const [baseFile, ...restFiles] = files;
+const base = JSON.parse(readFileSync(path.join(localesDir, baseFile), 'utf8'));
+const baseKeys = Object.keys(flatten(base));
+
+let hasError = false;
+
+for (const file of restFiles) {
+  const data = JSON.parse(readFileSync(path.join(localesDir, file), 'utf8'));
+  const keys = Object.keys(flatten(data));
+  const missing = baseKeys.filter(k => !keys.includes(k));
+  const extra = keys.filter(k => !baseKeys.includes(k));
+
+  if (missing.length || extra.length) {
+    hasError = true;
+    if (missing.length) {
+      console.error(`Missing keys in ${file}:`, missing.join(', '));
+    }
+    if (extra.length) {
+      console.error(`Extra keys in ${file}:`, extra.join(', '));
+    }
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+} else {
+  console.log('All locale files have matching keys.');
+}


### PR DESCRIPTION
## Summary
- add locale json files for English and Spanish
- add script to validate missing or extra translation keys
- document translation workflow in README

## Testing
- `pnpm lint --filter=@hikai/i18n`
- `pnpm i18n:check`
- `pnpm format:check` (fails: Code style issues found in 34 files. Run Prettier with --write to fix.)

------
https://chatgpt.com/codex/tasks/task_e_68a17029ca7c8332ae3574c5719304d4