### PR TITLE
feat: add i18n React provider and Node helpers

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,4 @@
+# Examples
+
+- `react` &mdash; basic React setup using `I18nProvider` and `useTranslation`.
+- `node` &mdash; minimal Node/CLI script loading dictionaries and translating.

--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -1,0 +1,14 @@
+import { loadDictionaries, setLanguage, t } from "@hikai/i18n";
+
+const resources = {
+  en: { common: { hello: "Hello" } },
+  es: { common: { hello: "Hola" } },
+};
+
+loadDictionaries(
+  { fallbackLng: "en", supportedLngs: ["en", "es"], defaultNS: "common" },
+  resources,
+);
+
+setLanguage("es");
+console.log(t("hello"));

--- a/examples/react/main.tsx
+++ b/examples/react/main.tsx
@@ -1,0 +1,25 @@
+import { I18nProvider, useTranslation } from "@hikai/i18n/react";
+import { loadDictionaries } from "@hikai/i18n";
+
+const resources = {
+  en: { common: { hello: "Hello" } },
+  es: { common: { hello: "Hola" } },
+};
+
+loadDictionaries(
+  { fallbackLng: "en", supportedLngs: ["en", "es"], defaultNS: "common" },
+  resources,
+);
+
+function Demo() {
+  const { t } = useTranslation();
+  return <h1>{t("hello")}</h1>;
+}
+
+export default function App() {
+  return (
+    <I18nProvider lang="es">
+      <Demo />
+    </I18nProvider>
+  );
+}

--- a/packages/i18n/core/index.ts
+++ b/packages/i18n/core/index.ts
@@ -8,7 +8,14 @@ export interface I18nConfig {
 
 export type Translations = Resource;
 
-export function initI18n(config: I18nConfig, translations: Translations) {
+/**
+ * Load dictionaries and initialise the i18next instance. This function is
+ * environment agnostic and can be used from Node/CLI applications.
+ */
+export function loadDictionaries(
+  config: I18nConfig,
+  translations: Translations,
+) {
   if (!i18n.isInitialized) {
     void i18n.init({
       fallbackLng: config.fallbackLng,
@@ -20,6 +27,9 @@ export function initI18n(config: I18nConfig, translations: Translations) {
     });
   }
 }
+
+// Backwards compatibility
+export const initI18n = loadDictionaries;
 
 export function setLanguage(lang: string) {
   const supported = i18n.options?.supportedLngs || [];
@@ -35,8 +45,11 @@ export function setLanguage(lang: string) {
   }
 }
 
-export function getTranslation(key: string, options?: Record<string, unknown>) {
+export function t(key: string, options?: Record<string, unknown>) {
   return i18n.t(key, options);
 }
+
+// Backwards compatibility
+export const getTranslation = t;
 
 export { i18n };

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -5,12 +5,19 @@
   "private": true,
   "dependencies": {
     "i18next": "^23.16.8",
+    "react-i18next": "^15.6.1",
     "@hikai/typescript-config": "workspace:*"
   },
-  "devDependencies": {},
+  "peerDependencies": {
+    "react": "^18 || ^19"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  },
   "exports": {
     ".": "./core/index.ts",
-    "./core": "./core/index.ts"
+    "./core": "./core/index.ts",
+    "./react": "./react/index.tsx"
   },
   "scripts": {
     "build": "tsc -b"

--- a/packages/i18n/react/index.tsx
+++ b/packages/i18n/react/index.tsx
@@ -1,0 +1,22 @@
+import { ReactNode, useEffect } from "react";
+import { I18nextProvider, useTranslation as useTranslationBase } from "react-i18next";
+import { i18n, setLanguage } from "../core";
+
+export interface I18nProviderProps {
+  lang: string;
+  children: ReactNode;
+}
+
+/**
+ * React provider that keeps the i18n instance in sync with the selected
+ * language. Intended for React apps that are not using Next.js.
+ */
+export function I18nProvider({ lang, children }: I18nProviderProps) {
+  useEffect(() => {
+    setLanguage(lang);
+  }, [lang]);
+
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+}
+
+export const useTranslation = useTranslationBase;

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -7,5 +7,5 @@
                 "composite": true,
                 "noEmit": false
         },
-        "include": ["core/**/*.ts"]
+        "include": ["core/**/*.ts", "react/**/*.tsx"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,16 @@ importers:
       i18next:
         specifier: ^23.16.8
         version: 23.16.8
+      react:
+        specifier: ^18 || ^19
+        version: 19.1.1
+      react-i18next:
+        specifier: ^15.6.1
+        version: 15.6.1(i18next@23.16.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.8.3)
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
 
   packages/tailwind-config:
     dependencies:
@@ -2437,6 +2447,9 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -3066,6 +3079,22 @@ packages:
     peerDependencies:
       react: ^19.1.1
 
+  react-i18next@15.6.1:
+    resolution: {integrity: sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==}
+    peerDependencies:
+      i18next: '>= 23.2.3'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -3625,6 +3654,10 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -5896,6 +5929,10 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -6490,6 +6527,16 @@ snapshots:
     dependencies:
       react: 19.1.1
       scheduler: 0.26.0
+
+  react-i18next@15.6.1(i18next@23.16.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.8.3):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      html-parse-stringify: 3.0.1
+      i18next: 23.16.8
+      react: 19.1.1
+    optionalDependencies:
+      react-dom: 19.1.1(react@19.1.1)
+      typescript: 5.8.3
 
   react-is@16.13.1: {}
 
@@ -7183,6 +7230,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  void-elements@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- expose `I18nProvider` and `useTranslation` for React apps without Next.js
- add `loadDictionaries`/`t` helpers for Node or CLI usage
- provide usage samples under `examples/`

## Testing
- `pnpm --filter @hikai/i18n build`


------
https://chatgpt.com/codex/tasks/task_e_68a17028ed8c83329b20c1838cd1a07b