### PR TITLE
feat: add react i18n utilities

### DIFF
--- a/packages/i18n/index.ts
+++ b/packages/i18n/index.ts
@@ -1,0 +1,2 @@
+export * from "./core";
+export * from "./react";

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,16 +1,20 @@
 {
   "name": "@hikai/i18n",
   "version": "0.0.0",
-  "main": "core/index.ts",
+  "main": "index.ts",
   "private": true,
   "dependencies": {
     "i18next": "^23.16.8",
     "@hikai/typescript-config": "workspace:*"
   },
+  "peerDependencies": {
+    "react": "^19.1.1"
+  },
   "devDependencies": {},
   "exports": {
-    ".": "./core/index.ts",
-    "./core": "./core/index.ts"
+    ".": "./index.ts",
+    "./core": "./core/index.ts",
+    "./react": "./react/index.ts"
   },
   "scripts": {
     "build": "tsc -b"

--- a/packages/i18n/react/I18nProvider.tsx
+++ b/packages/i18n/react/I18nProvider.tsx
@@ -1,0 +1,24 @@
+import { type ReactNode } from "react";
+import { initI18n, type I18nConfig, type Translations } from "../core";
+import { syncLanguage } from "./syncLanguage";
+
+interface I18nProviderProps {
+  config: I18nConfig;
+  translations: Translations;
+  lang?: string;
+  children: ReactNode;
+}
+
+// Initializes i18n and optionally sets the initial language.
+export function I18nProvider({
+  config,
+  translations,
+  lang,
+  children,
+}: I18nProviderProps) {
+  initI18n(config, translations);
+  if (lang) {
+    syncLanguage(lang);
+  }
+  return <>{children}</>;
+}

--- a/packages/i18n/react/index.ts
+++ b/packages/i18n/react/index.ts
@@ -1,0 +1,3 @@
+export { I18nProvider } from "./I18nProvider";
+export { useTranslation } from "./useTranslation";
+export { syncLanguage } from "./syncLanguage";

--- a/packages/i18n/react/syncLanguage.ts
+++ b/packages/i18n/react/syncLanguage.ts
@@ -1,0 +1,7 @@
+import { setLanguage } from "../core";
+
+// Changes the language synchronously. Designed for SSR/SSG where
+// side effects like useEffect are not available.
+export function syncLanguage(lang: string) {
+  setLanguage(lang);
+}

--- a/packages/i18n/react/useTranslation.ts
+++ b/packages/i18n/react/useTranslation.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from "react";
+import { getTranslation, i18n } from "../core";
+
+// Hook to access the translation function and current language.
+export function useTranslation() {
+  const lang = useSyncExternalStore(
+    (callback) => {
+      i18n.on("languageChanged", callback);
+      return () => i18n.off("languageChanged", callback);
+    },
+    () => i18n.language,
+    () => i18n.language,
+  );
+
+  return { t: getTranslation, lang };
+}

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -7,5 +7,5 @@
                 "composite": true,
                 "noEmit": false
         },
-        "include": ["core/**/*.ts"]
+        "include": ["core/**/*.ts", "react/**/*.ts", "react/**/*.tsx", "index.ts"]
 }


### PR DESCRIPTION
## Summary
- add React-based i18n provider and hook
- implement syncLanguage helper for SSR/SSG
- expose core and react utilities from package root

## Testing
- `pnpm --filter @hikai/i18n build`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a17027ebec8332b99ebb918fe3ff27