### PR TITLE
feat: add website locales

### DIFF
--- a/packages/locales/index.ts
+++ b/packages/locales/index.ts
@@ -1,0 +1,2 @@
+export { default as websiteEn } from "./website/en.json";
+export { default as websiteEs } from "./website/es.json";

--- a/packages/locales/package.json
+++ b/packages/locales/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@hikai/locales",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.ts"
+}

--- a/packages/locales/tsconfig.json
+++ b/packages/locales/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@hikai/typescript-config/base",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "noEmit": false
+  },
+  "include": ["**/*.ts", "**/*.json"]
+}

--- a/packages/locales/website/en.json
+++ b/packages/locales/website/en.json
@@ -1,0 +1,21 @@
+{
+  "nav": {
+    "features": "Features",
+    "waitlist": "Waitlist"
+  },
+  "hero": {
+    "title": "Stand out with AI",
+    "subtitle": "SEO content manager powered by AI agents.",
+    "cta": "Join waitlist"
+  },
+  "features": {
+    "title": "Features",
+    "item1": "Content planning",
+    "item2": "SEO optimization",
+    "item3": "Analytics"
+  },
+  "waitlist": {
+    "title": "Join the waitlist",
+    "cta": "Sign up"
+  }
+}

--- a/packages/locales/website/es.json
+++ b/packages/locales/website/es.json
@@ -1,0 +1,21 @@
+{
+  "nav": {
+    "features": "Características",
+    "waitlist": "Lista de espera"
+  },
+  "hero": {
+    "title": "Destácate con IA",
+    "subtitle": "Administrador de contenido SEO impulsado por agentes de IA.",
+    "cta": "Unirse a la lista"
+  },
+  "features": {
+    "title": "Características",
+    "item1": "Planificación de contenido",
+    "item2": "Optimización SEO",
+    "item3": "Analítica"
+  },
+  "waitlist": {
+    "title": "Únete a la lista de espera",
+    "cta": "Regístrate"
+  }
+}


### PR DESCRIPTION
## Summary
- add website translation package with English and Spanish dictionaries
- expose website dictionaries from locales index

## Testing
- `pnpm lint`
- `pnpm i18n:check`


------
https://chatgpt.com/codex/tasks/task_e_68a17aa967e88332adfef5b74a9b3d70