### PR TITLE
Use requestLocale for website i18n configuration

### DIFF
--- a/apps/website/i18n.ts
+++ b/apps/website/i18n.ts
@@ -1,8 +1,12 @@
-import { getRequestConfig } from "next-intl/server";
+import { getRequestConfig, requestLocale } from "next-intl/server";
 
-export default getRequestConfig(async ({ locale }) => ({
-  messages: (await import(`./messages/${locale}.json`)).default,
-}));
+export default getRequestConfig(async () => {
+	const locale = await requestLocale();
+
+	return {
+		messages: (await import(`./messages/${locale}.json`)).default,
+	};
+});
 
 export const locales = ["en", "es"];
 export const defaultLocale = "en";


### PR DESCRIPTION
## Summary
- use `requestLocale` from `next-intl/server` for locale detection
- load messages based on detected locale in website i18n config

## Testing
- `pnpm exec prettier apps/website/i18n.ts --check`
- `pnpm lint --filter=website`
- `pnpm i18n:check`
- `pnpm test --filter=website`


------
https://chatgpt.com/codex/tasks/task_e_68a18cc33b088332a034e5e5d7c1512d