### PR TITLE
feat: use next-intl middleware

### DIFF
--- a/apps/website/middleware.ts
+++ b/apps/website/middleware.ts
@@ -1,9 +1,11 @@
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
+import createMiddleware from "next-intl/middleware";
+import { locales, defaultLocale } from "./i18n";
 
-export function middleware(request: NextRequest) {
-  if (request.nextUrl.pathname === "/") {
-    return NextResponse.redirect(new URL("/en", request.url));
-  }
-  return NextResponse.next();
-}
+export default createMiddleware({
+	locales,
+	defaultLocale,
+});
+
+export const config = {
+	matcher: ["/", "/(en|es)/:path*"],
+};


### PR DESCRIPTION
## Summary
- replace manual redirect with next-intl middleware

## Testing
- `npx prettier apps/website/middleware.ts --check`
- `pnpm --filter website lint`


------
https://chatgpt.com/codex/tasks/task_e_68a19084d58083328d744bbd909fe12a